### PR TITLE
Feature/remove preview in nextjs

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -9,7 +9,7 @@ const nextConfig = {
         ],
         deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
         imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
-        dangerouslyAllowSVG: true,
+        dangerouslyAllowSVG: false,
         contentDispositionType: 'attachment',
         contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     },

--- a/next.config.js
+++ b/next.config.js
@@ -9,6 +9,9 @@ const nextConfig = {
         ],
         deviceSizes: [640, 750, 828, 1080, 1200, 1920, 2048, 3840],
         imageSizes: [16, 32, 48, 64, 96, 128, 256, 384],
+        dangerouslyAllowSVG: true,
+        contentDispositionType: 'attachment',
+        contentSecurityPolicy: "default-src 'self'; script-src 'none'; sandbox;",
     },
 };
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,7 @@
       "version": "0.0.0-development",
       "license": "MIT",
       "dependencies": {
-        "@ost-cas-fee-adv-23-24/design-system-pixelpioneers": "^5.3.5",
+        "@ost-cas-fee-adv-23-24/design-system-pixelpioneers": "^5.4.0",
         "@types/react": "18.2.21",
         "@types/react-dom": "18.2.7",
         "autoprefixer": "10.4.15",
@@ -3644,9 +3644,9 @@
       }
     },
     "node_modules/@ost-cas-fee-adv-23-24/design-system-pixelpioneers": {
-      "version": "5.3.5",
-      "resolved": "https://registry.npmjs.org/@ost-cas-fee-adv-23-24/design-system-pixelpioneers/-/design-system-pixelpioneers-5.3.5.tgz",
-      "integrity": "sha512-ROK4m6pNHCtiy2Yz6lFv8jPeJi79O/Q+a4vQG4Rbx3A/BsN7JrvhfTjBr/Q0/pbfxNsshERs9+DgefqU88dIcA==",
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@ost-cas-fee-adv-23-24/design-system-pixelpioneers/-/design-system-pixelpioneers-5.4.0.tgz",
+      "integrity": "sha512-BvpUQSXcYmpTL9wtZa1GRqFM/1TSSZaIue5sT6HTok2oqTze+OunrE+d/Lt0c2LtNSy5I/JE3uumwEY/6lai4w==",
       "dependencies": {
         "@headlessui/react": "^1.7.17",
         "clsx": "^2.0.0",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,7 @@
     ]
   },
   "dependencies": {
-    "@ost-cas-fee-adv-23-24/design-system-pixelpioneers": "^5.3.5",
+    "@ost-cas-fee-adv-23-24/design-system-pixelpioneers": "^5.4.0",
     "@types/react": "18.2.21",
     "@types/react-dom": "18.2.7",
     "autoprefixer": "10.4.15",

--- a/src/components/image-header/image-header.tsx
+++ b/src/components/image-header/image-header.tsx
@@ -28,7 +28,6 @@ export default function ImageHeader({
                 sizes="(max-width: 680px) 100vw"
                 style={{
                     width: '100%',
-                    height: 'auto',
                 }}
             />
             <div className="absolute bottom-[-25px] right-[15px] z-10 md:bottom-[-70px] md:right-[30px]">
@@ -36,6 +35,7 @@ export default function ImageHeader({
                     <EditAvatar
                         src={user.avatarUrl}
                         alt={avatarAlt}
+                        size={AvatarSize.XL}
                         onEdit={() => console.info('open pop up')}
                     />
                 ) : (

--- a/src/components/image-header/image-header.tsx
+++ b/src/components/image-header/image-header.tsx
@@ -30,14 +30,26 @@ export default function ImageHeader({
                     width: '100%',
                 }}
             />
-            <div className="absolute bottom-[-25px] right-[15px] z-10 md:bottom-[-70px] md:right-[30px]">
+            <div className="absolute bottom-[-25px] right-[24px] z-10 md:bottom-[-70px] md:right-[30px]">
                 {activeUser ? (
-                    <EditAvatar
-                        src={user.avatarUrl}
-                        alt={avatarAlt}
-                        size={AvatarSize.XL}
-                        onEdit={() => console.info('open pop up')}
-                    />
+                    <>
+                        <div className="hidden md:block">
+                            <EditAvatar
+                                src={user.avatarUrl}
+                                alt={avatarAlt}
+                                size={AvatarSize.XL}
+                                onEdit={() => console.info('open pop up')}
+                            />
+                        </div>
+                        <div className="block md:hidden">
+                            <EditAvatar
+                                src={user.avatarUrl}
+                                alt={avatarAlt}
+                                size={AvatarSize.L}
+                                onEdit={() => console.info('open pop up')}
+                            />
+                        </div>
+                    </>
                 ) : (
                     <Avatar src={user?.avatarUrl} alt={avatarAlt} size={AvatarSize.XL} />
                 )}

--- a/src/components/image-header/image-header.tsx
+++ b/src/components/image-header/image-header.tsx
@@ -12,12 +12,11 @@ export default function ImageHeader({
     user: User;
     activeUser?: boolean;
 }) {
-    const pathToBgImage = 'my-profile.jpg';
-    const avatarAlt = user.avatarUrl ? `avatar from ${user.username}` : 'no image';
+    const avatarAlt = user.avatarUrl ? `Avatarbild von ${user.username}` : 'Kein Bild';
     return (
         <div className="relative flex h-[200px] w-full flex-row bg-primary-600 object-cover md:h-[320px] md:w-[680px] md:rounded-m md:object-contain">
             <Image
-                src={`/wallpapers/${pathToBgImage}`}
+                src={`/wallpapers/my-profile.jpg`}
                 alt="Hintergrundbild Profil"
                 className="cursor-pointer md:rounded-m"
                 fill

--- a/src/components/post-form/post-form.tsx
+++ b/src/components/post-form/post-form.tsx
@@ -3,17 +3,12 @@
 import {
     Avatar,
     AvatarSize,
-    Button,
-    ButtonSize,
-    IconCancel,
     Label,
     LabelSize,
     Textarea,
-    Variant,
 } from '@ost-cas-fee-adv-23-24/design-system-pixelpioneers';
 import { MessageVariant } from '../../compositions/post/types';
 import { User } from '@/src/models/user.model';
-import Image from 'next/image';
 import DisplayName from '@/src/compositions/display-name/display-name';
 import { DisplayNameVariant } from '@/src/compositions/display-name/types';
 import ActionButton from '@/src/compositions/write-post/action-button';
@@ -74,42 +69,6 @@ export default function PostForm({
                     </div>
                 ) : (
                     <DisplayName variant={DisplayNameVariant.REPLY} user={user} />
-                )}
-                {image && (
-                    <>
-                        <div className="w-fill relative mx-auto h-auto rounded-m bg-violet-50 p-xs">
-                            <Image
-                                src={image}
-                                alt="Bildvorschau"
-                                className="mx-auto rounded-m"
-                                quality={75}
-                                width={300}
-                                height={200}
-                                loading="eager"
-                                priority
-                                aria-label="Bildvorschau"
-                                sizes="(max-width: 300px) 100vw"
-                                style={{
-                                    width: '100%',
-                                    height: 'auto',
-                                }}
-                            />
-                        </div>
-                        <Button
-                            onClick={() => {
-                                setImage(null);
-                                if (imageRef.current) {
-                                    imageRef.current.value = '';
-                                }
-                            }}
-                            size={ButtonSize.M}
-                            type="button"
-                            Icon={IconCancel}
-                            variant={Variant.PRIMARY}
-                            fill
-                            label="Bild löschen"
-                        />
-                    </>
                 )}
                 <Textarea
                     className="h-15xl resize-none rounded-m border-2 border-secondary-200 bg-secondary-50 p-m"


### PR DESCRIPTION
TODO (@aceres):

- [x] avoid upload other image with not allowed extension like .svg, .gif etc. :)
- [x] remove via curl the already added / uploaded image with the extension .svg. (until now - 2 images with .svg exist) 
- [x] update new version of design component and test upload form again

Change Logs:

- update design component version (5.4.0)
- remove preview image from the post form component
- remove height style of Image in profile header (since we have fill prop there)
- add L size of the edit avatar for the mobile view
- add a better CSP policies in connected with Image (in the next.config.js)
(https://nextjs.org/docs/pages/api-reference/components/image#dangerouslyallowsvg)

Screenshot (mobile view)
<img width="407" alt="Screenshot 2024-04-16 at 18 30 47" src="https://github.com/ost-cas-fee-adv-23-24/nextjs-app-pixelpioneers/assets/1326993/f541f52f-9975-48d0-b606-1a85256b5e21">
