### PR TITLE
feat(fix-line-clamp-message): fix line clamp for mobile view and add display as swap for fonts

### DIFF
--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -26,6 +26,7 @@ const poppins = Poppins({
     weight: ['500', '600', '700'],
     fallback: ['arial', 'sans-serif'],
     adjustFontFallback: false,
+    display: 'swap',
 });
 
 export default async function RootLayout({ children }: { children: ReactNode }) {

--- a/src/compositions/message/message.tsx
+++ b/src/compositions/message/message.tsx
@@ -55,9 +55,11 @@ export default function Message({ message, displayVariant, children }: MessagePr
         'z-5 relative row-span-3', // mobile
         'md:absolute md:left-[-32px] md:top-[20px]', // desktop
     );
-    const lineClamp = clsx(
+    const shortTextOfPost = clsx(
         'break-all text-secondary-900',
-        isVariant(MessageDisplayVariant.DETAIL_VIEW) ? '' : 'line-clamp-4 md:line-clamp-none',
+        isVariant(MessageDisplayVariant.DETAIL_VIEW) || isVariant(MessageDisplayVariant.INLINE)
+            ? ''
+            : 'line-clamp-5 md:line-clamp-none',
     );
 
     return (
@@ -89,7 +91,7 @@ export default function Message({ message, displayVariant, children }: MessagePr
                         route={getRoute(APP_ROUTES.POST, message.id)}
                     >
                         <Paragraph
-                            className={clsx('break-all text-secondary-900', lineClamp)}
+                            className={clsx('break-all text-secondary-900', shortTextOfPost)}
                             size={
                                 isVariant(MessageDisplayVariant.DETAIL_VIEW)
                                     ? ParagraphSize.L

--- a/src/compositions/message/message.tsx
+++ b/src/compositions/message/message.tsx
@@ -57,9 +57,7 @@ export default function Message({ message, displayVariant, children }: MessagePr
     );
     const shortTextOfPost = clsx(
         'break-all text-secondary-900',
-        isVariant(MessageDisplayVariant.DETAIL_VIEW) || isVariant(MessageDisplayVariant.INLINE)
-            ? ''
-            : 'line-clamp-5 md:line-clamp-none',
+        isVariant(MessageDisplayVariant.TIMELINE) ? 'line-clamp-5 md:line-clamp-none' : '',
     );
 
     return (
@@ -91,7 +89,7 @@ export default function Message({ message, displayVariant, children }: MessagePr
                         route={getRoute(APP_ROUTES.POST, message.id)}
                     >
                         <Paragraph
-                            className={clsx('break-all text-secondary-900', shortTextOfPost)}
+                            className={shortTextOfPost}
                             size={
                                 isVariant(MessageDisplayVariant.DETAIL_VIEW)
                                     ? ParagraphSize.L

--- a/src/compositions/message/message.tsx
+++ b/src/compositions/message/message.tsx
@@ -55,6 +55,11 @@ export default function Message({ message, displayVariant, children }: MessagePr
         'z-5 relative row-span-3', // mobile
         'md:absolute md:left-[-32px] md:top-[20px]', // desktop
     );
+    const lineClamp = clsx(
+        'break-all text-secondary-900',
+        isVariant(MessageDisplayVariant.DETAIL_VIEW) ? '' : 'line-clamp-4 md:line-clamp-none',
+    );
+
     return (
         <div className={messageClasses} data-testid="testPostMessage">
             <div className="flex flex-row items-center gap-s md:flex-col md:items-start">
@@ -84,7 +89,7 @@ export default function Message({ message, displayVariant, children }: MessagePr
                         route={getRoute(APP_ROUTES.POST, message.id)}
                     >
                         <Paragraph
-                            className="line-clamp-4 break-all text-secondary-900 md:line-clamp-none"
+                            className={clsx('break-all text-secondary-900', lineClamp)}
                             size={
                                 isVariant(MessageDisplayVariant.DETAIL_VIEW)
                                     ? ParagraphSize.L


### PR DESCRIPTION
- in mobile view, we do have line clamp to max. 4 lines in the timeline view (home route)
- in the detail view of post (replies) - we have no line clamp configured
- add swap font